### PR TITLE
fix: claude-code-actionのツール許可設定を修正

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -111,7 +111,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_tools: "Write,Edit,Bash,Read,Glob,Grep"
+          claude_args: '--max-turns 50 --allowed-tools "Read,Grep,Glob,Edit,Write,Bash(npm run *),Bash(mkdir *)"'
           prompt: |
             ## タスク
             Issue #${{ matrix.issue.number }} の内容に基づいて実装してください。


### PR DESCRIPTION
## Summary

- 自動実装ワークフローでClaude CodeのWriteツールが`permission_denials`で拒否されていた問題を修正
- `allowed_tools`パラメータ（v1で廃止済み）を`claude_args`の`--allowed-tools`フラグに移行
- 参照実装（claude-code-marketplace）のパターンに統一

## Changes

| 項目 | 修正前 | 修正後 |
|------|--------|--------|
| パラメータ | `allowed_tools` (廃止済み) | `claude_args: --allowed-tools` |
| フラグ形式 | 無効なパラメータ | カンマ区切り+ダブルクォート |
| ツール | Write,Edit,Bash,Read,Glob,Grep | Read,Grep,Glob,Edit,Write,Bash(npm run *),Bash(mkdir *) |
| max-turns | なし | 50 |

## Test plan

- [ ] ワークフロー手動実行で`permission_denials`が解消されること
- [ ] Writeツールでファイルが作成されPRが生成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)