### PR TITLE
fix: 自動実装ワークフローの重複PR生成を防止

### DIFF
--- a/.github/workflows/claude-auto-implement.yml
+++ b/.github/workflows/claude-auto-implement.yml
@@ -30,8 +30,8 @@ jobs:
             --json number,title,labels \
             --limit 10)
 
-          # implementingラベル付きを除外
-          filtered=$(echo "$issues" | jq '[.[] | select(.labels | map(.name) | contains(["implementing"]) | not)]')
+          # implementing / implemented / auto-implement-failed ラベル付きを除外
+          filtered=$(echo "$issues" | jq '[.[] | select(.labels | map(.name) as $names | (($names | contains(["implementing"])) or ($names | contains(["implemented"])) or ($names | contains(["auto-implement-failed"]))) | not)]')
 
           # 最大2件に制限
           limited=$(echo "$filtered" | jq '.[0:2]')
@@ -228,7 +228,8 @@ jobs:
         run: |
           gh issue edit ${{ matrix.issue.number }} \
             --repo ${{ github.repository }} \
-            --add-label "implemented"
+            --add-label "implemented" \
+            --remove-label "auto-implement"
 
           gh issue comment ${{ matrix.issue.number }} \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

- 自動実装ワークフローのフィルタリングロジックを修正し、`implemented` / `auto-implement-failed` ラベル付きIssueが再処理されないようにした
- 成功時に `auto-implement` ラベルを削除する安全策を追加
- 重複PR（#32, #33, #34, #35, #36, #37）をクローズ済み

## Background

`implementing` ラベルのみ除外していたため、`implemented` ラベル付きのIssueが5時間ごとに再処理され、PR #29 と #30 に対して4つずつ重複PRが生成されていた。

## Changes

1. **フィルタリングロジック修正**: `implementing` に加え `implemented` と `auto-implement-failed` も除外
2. **ラベル運用改善**: 実装成功時に `auto-implement` ラベルを削除（二重の安全策）

## Test plan

- [x] jqフィルタのローカル検証: `implemented` ラベル付きIssueが正しく除外されることを確認
- [x] textlintエラーなし
- [ ] `workflow_dispatch` で手動実行し、`implemented` ラベル付きIssueが処理されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)